### PR TITLE
Added intersect opt to sysmodules

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@ AC_PATH_PROG([APT_CACHE], [apt-cache], [notfound])
 AS_IF([test "x$APT_CACHE" = xnotfound], [AC_MSG_ERROR([apt-cache is required.])])
 
 AC_MSG_CHECKING([for node modules that have to be installed from Ubuntu repos])
-AC_SUBST([eos_node_system_modules], [`$srcdir/sysmodules.py`])
+AC_SUBST([eos_node_system_modules], [`$srcdir/sysmodules.py --format node`])
 AC_MSG_RESULT([ok])
 
 AC_CONFIG_FILES([package.json Makefile])


### PR DESCRIPTION
sysmodules.py now takes an optional --intersect parameter that denotes a
package.json file with which the list of system modules should be intersected.
Also added a switch that controls the format of output node modules, where
--format=deb results in a comma separated list of "node-{MODULENAME}" while
--format=node results in a space separated list of just "{MODULENAME}"

[endlessm/eos-sdk#1123]
