### PR TITLE
Runtime deps are autogenerated by python script

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,8 @@ Vcs-Git: https://github.com/endlessm/eos-node-modules
 
 Package: eos-node-modules
 Architecture: any
-Depends: ${misc:Depends}
+Depends: ${misc:Depends},
+         ${npm:Overlaps}
 Suggests: nodejs
 Conflicts: node-autoquit,
            node-express,

--- a/debian/rules
+++ b/debian/rules
@@ -4,5 +4,11 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+OVERLAPS=`./sysmodules.py --intersect package.json --format deb`
+SUBSTVARS=-Vnpm:Overlaps="$(OVERLAPS)"
+
 %:
 	dh $@
+
+override_dh_gencontrol:
+	dh_gencontrol -- $(SUBSTVARS)


### PR DESCRIPTION
eos-node-modules will not install node modules which are already installed by
other packages. As a result, if our package.json has a module that's installed
by e.g. npm, it won't be included in this debian. So instead, include that
shared module as a runtime dep

merge with #5 

[endlessm/eos-sdk#1123]
