### PR TITLE
Replaced i18n with i18n-moustache

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+eos-node-modules (0.1.0) UNRELEASED; urgency=medium
+
+  * Switched from i18n to i18n-moustache
+
+ -- Will G <will@endlessm.com>  Fri, 30 May 2014 11:54:55 -0700
+
 eos-node-modules (0.0.0) unstable; urgency=low
 
   * Initial Release.

--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,6 @@ Suggests: nodejs
 Conflicts: node-autoquit,
            node-express,
            node-htmlparser2,
-           node-i18n,
            node-jade,
            node-jsonld,
            node-keypress,

--- a/debian/eos-node-modules.install
+++ b/debian/eos-node-modules.install
@@ -1,7 +1,7 @@
 usr/lib/nodejs/autoquit
 usr/lib/nodejs/express
 usr/lib/nodejs/htmlparser2
-usr/lib/nodejs/i18n
+usr/lib/nodejs/i18n-moustache
 usr/lib/nodejs/jade
 usr/lib/nodejs/jsonld
 usr/lib/nodejs/keypress


### PR DESCRIPTION
Updated minor version for this change

[endlessm/eos-sdk#1140]
