### PR TITLE
Knowledge Engine now uses systemd, autoquit

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Definitely don't upgrade modules just because there is a new major version avail
 Module index
 ------------
 - **apidoc**: eos-knowledge-engine (dev)
-- **autoquit**: eos-wikipedia-offline, eos-newspaper-server
+- **autoquit**: eos-wikipedia-offline, eos-newspaper-server, eos-knowledge-engine
 - **express**: eos-knowledge-engine, eos-wikipedia-offline, eos-newspaper-server
 - **frisby**: eos-knowledge-engine (dev)
 - **htmlparser2**: eos-newspaper-updater
@@ -66,5 +66,5 @@ Module index
 - **rewire**: eos-knowledge-engine (dev)
 - **socket.io**: eos-knowledge-engine, eos-wikipedia-offline
 - **supertest**: eos-knowledge-engine (dev)
-- **systemd**: eos-wikipedia-offline, eos-newspaper-server
+- **systemd**: eos-wikipedia-offline, eos-newspaper-server, eos-knowledge-engine
 - **xml2js**: eos-newspaper-updater


### PR DESCRIPTION
[endlessm/eos-sdk#1079]
