### PR TITLE
Sdk/2575

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,11 @@ For the most part, this is as simple as adding the module to `dependencies` or `
 Go through the following checklist:
 
 - add the module and its version to `dependencies` or `devDependencies` in `package.json.in` (see Note about Versions, below.)
-- run `make` and make sure the module is downloaded and compiled correctly.
+- run `autogen.sh` followed by `make` and make sure the module is downloaded and compiled correctly.
 - run `DESTDIR=staging make install` to test installing into a staging directory.
 - in line 1 of `configure.ac`, increment the *minor* version of the `eos-node-modules` package. (For example, from 0.5.0 to 0.6.0.) Your package should now depend on `eos-node-modules (>= 0.6)` (or build-depend on `eos-node-modules-dev (>= 0.6)`.)
 - add the module to the Module Index at the bottom of this readme file. Specify the name of your package. Maintain alphabetical order for others' convenience.
-- add yourself to `contributors` :smile:
-- add the usual `Version_x.y.z` and `Version_x.y.z_debian` tags to the git repo.
+- add the usual `Version_x.y.z` to the `master` branch and `Version_x.y.z_debian` tags to the `debian-master` branch of this `eos-node-modules` git repo.
 
 Removing a module
 -----------------

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Module index
 - **istanbul**: eos-knowledge-engine (dev)
 - **jade**: eos-knowledge-engine
 - **jasmine-node**: eos-knowledge-engine (dev)
+- **jscs**: eos-dev-config (dev)
+- **jshint**: eos-dev-config (dev)
 - **jsonld**: eos-knowledge-engine
 - **lcov-result-merger**: eos-sdk (dev)
 - **mime**: eos-knowledge-engine

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([eos-node-modules], [1.0.0])
+AC_INIT([eos-node-modules], [1.1.0])
 dnl tar-pax is required instead of tar-ustar, because there are very long paths
 dnl in the node_modules trees.
 AM_INIT_AUTOMAKE([foreign dist-xz no-dist-gzip tar-pax -Wall])

--- a/package.json.in
+++ b/package.json.in
@@ -25,6 +25,8 @@
   "devDependencies": {
     "apidoc": "^0.4",
     "frisby": "^0.7",
+    "jscs": "*",
+    "jshint": "*",
     "rewire": "^2.0",
     "supertest": "^0.10",
     "jasmine-node": "^1.12",


### PR DESCRIPTION
Add JSCS and JSHint packages in addition to some cleanup of the README's instructions on how to add modules.

https://github.com/endlessm/eos-sdk/issues/2575