### PR TITLE
Keep dh_fixperms out of bin dirs

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -25,6 +25,9 @@ override_dh_install:
 
 	dh_install
 
+override_dh_fixperms:
+	dh_fixperms -Xbin
+
 %:
 	dh $@
 


### PR DESCRIPTION
It seems that when dh_fixperms runs, it resets the permissions on some
scripts that are supposed to be executable.

https://phabricator.endlessm.com/T9740